### PR TITLE
feat: enable Youtube embed link

### DIFF
--- a/src/components/Article/Article.Block.tsx
+++ b/src/components/Article/Article.Block.tsx
@@ -49,6 +49,24 @@ export const RenderArticleBlock = ({
             />
           )
         }
+        case 'p': {
+          const isIframeRegex = /<iframe[^>]*>(?:<\/iframe>|[^]*?<\/iframe>)/
+
+          const isIframe = isIframeRegex.test(block.text)
+
+          return isIframe ? (
+            <IframeContainer dangerouslySetInnerHTML={{ __html: block.text }} />
+          ) : (
+            <Paragraph
+              variant="body1"
+              component={block.tagName as any}
+              genericFontFamily="sans-serif"
+              className={extractClassFromFirstTag(block.html) || ''}
+              id={extractIdFromFirstTag(block.html) || `p-${block.order}`}
+              dangerouslySetInnerHTML={{ __html: extractInnerHtml(block.html) }}
+            />
+          )
+        }
         default:
           return (
             <Paragraph
@@ -71,5 +89,23 @@ const Paragraph = styled(Typography)`
   &#p-2 {
     font-size: var(--lsd-h6-fontSize);
     line-height: var(--lsd-h6-lineHeight);
+  }
+`
+
+const IframeContainer = styled.div`
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+
+  & > iframe,
+  & > object,
+  & > embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
   }
 `

--- a/src/utils/ui.utils.ts
+++ b/src/utils/ui.utils.ts
@@ -83,7 +83,6 @@ export function useIntersectionObserver(
       headings.forEach((heading) => {
         if (heading.isIntersecting && heading.target instanceof HTMLElement) {
           const targetId = heading.target.getAttribute('id')
-          console.log(targetId)
           if (targetId) setActiveId(targetId)
         }
       })


### PR DESCRIPTION
**1. Copy embed link**

<img width="750" alt="2023-08-02_12 38 17" src="https://github.com/acid-info/lpe-frontend/assets/41753422/48dcc7c8-3463-4104-9657-d7a382379f39">

<br />

**2. Paste it to Google Docs**
<img width="698" alt="1" src="https://github.com/acid-info/lpe-frontend/assets/41753422/dd0ba620-d4f6-4a4c-84ec-5a5f67961577">

<br />

**3. Desktop**
<img width="1046" alt="2" src="https://github.com/acid-info/lpe-frontend/assets/41753422/ec1bdaec-d9fb-4242-93b3-c2e0ab5f896e">

<br />

**4. Mobile**
<img width="371" alt="3" src="https://github.com/acid-info/lpe-frontend/assets/41753422/66182ec7-aa9c-4b93-9960-b5b8c58ff821">

<br />

FYI, CSS to make iframe responsive

```css
{
  position: relative;
  padding-bottom: 56.25%;
  padding-top: 30px;
  height: 0;
  overflow: hidden;
  
  & > iframe,
  & > object,
  & > embed {
    position: absolute;
    top: 0;
    left: 0;
    width: 100%;
    height: 100%;
  }
}
```

WIP for https://github.com/acid-info/lpe-frontend/issues/69

BTW, current `develop` branch has some issue with

- @hookstate/localstored => might need to be added to the package.json file ?

- yarn build type errors (e.g., injectCssVars at <ThemeProvider theme={theme.current} injectCssVars={false}>)