### PR TITLE
Add thumbnail and episode data to GlobalAudioPlayer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
     reactStrictMode: true,
     images: {
-        domains: ['images.cdn.unbody.io'],
+        domains: ['images.cdn.unbody.io', 'image.simplecastcdn.com'],
         // loader: 'imgix',
         // path: 'https://images.cdn.unbody.io',
     }

--- a/src/utils/data.utils.ts
+++ b/src/utils/data.utils.ts
@@ -25,7 +25,7 @@ export const shuffle = (array: any[]) => {
 
 export const unique = (arr: any[]) => Array.from(new Set(arr))
 
-export const getAudioSourceFromSimplecastPlayer = async (url: string) => {
+export const getAudioSourceFromEpisode = async (episodId: string) => {
   const myHeaders = new Headers()
   myHeaders.append(
     'Authorization',
@@ -38,11 +38,10 @@ export const getAudioSourceFromSimplecastPlayer = async (url: string) => {
   }
 
   const result = await fetch(
-    `https://api.simplecast.com/episodes/${url}`,
+    `https://api.simplecast.com/episodes/${episodId}`,
     requestOptions,
   )
 
   const data = await result.json()
-  console.log(data)
   return data
 }


### PR DESCRIPTION
Demo:

https://github.com/acid-info/lpe-frontend/assets/41753422/580514a7-34b9-4a52-9ecb-23a5b9df2a6f

1. Get audio src, episode metadata with episodeId 
=> use Simplecast API `https://api.simplecast.com/episodes/30d4e2f5-4434-419c-8fc1-a76e4b367e20`

2. Use react-player for persistant audio playing for all the media files (audio, video, youtubue, simplecast, etc.)

Figma: https://www.figma.com/file/YPw6IQMkg7aybAZWxjrkrB/UI-V1?node-id=228%3A17388&mode=dev