### PR TITLE
Basic LightBox component for article images

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-dom": "18.2.0",
     "react-imgix": "^9.7.0",
     "react-player": "^2.12.0",
+    "react-quick-pinch-zoom": "^4.9.0",
     "react-use": "^17.4.0",
     "typescript": "5.0.4",
     "use-query-params": "^2.2.1"

--- a/src/components/Article/Article.ImageBlockWrapper.tsx
+++ b/src/components/Article/Article.ImageBlockWrapper.tsx
@@ -1,6 +1,7 @@
 import { lsdUtils } from '@/utils/lsd.utils'
 import styled from '@emotion/styled'
 import { LPE } from '../../types/lpe.types'
+import { LightBox } from '../LightBox'
 import { ResponsiveImage } from '../ResponsiveImage/ResponsiveImage'
 
 type Props = {
@@ -11,7 +12,9 @@ type Props = {
 export const ArticleImageBlockWrapper = ({ image, order }: Props) => {
   return (
     <Container id={`i-${order}`}>
-      <ResponsiveImage data={image} />
+      <LightBox>
+        <ResponsiveImage data={image} />
+      </LightBox>
       <figcaption>{image.alt}</figcaption>
     </Container>
   )

--- a/src/components/Icons/ExitFullscreenIcon/ExitFullscreenIcon.tsx
+++ b/src/components/Icons/ExitFullscreenIcon/ExitFullscreenIcon.tsx
@@ -11,7 +11,7 @@ export const ExitFullscreenIcon = LsdIcon(
       {...props}
     >
       <path
-        fill={props.fill || 'white'}
+        fill="white"
         d="M 8 19 L 8 16 L 5 16 L 5 14 L 10 14 L 10 19 Z M 14 19 L 14 14 L 19 14 L 19 16 L 16 16 L 16 19 Z M 5 10 L 5 8 L 8 8 L 8 5 L 10 5 L 10 10 Z M 14 10 L 14 5 L 16 5 L 16 8 L 19 8 L 19 10 Z M 14 10 "
       />
     </svg>

--- a/src/components/Icons/ExitFullscreenIcon/ExitFullscreenIcon.tsx
+++ b/src/components/Icons/ExitFullscreenIcon/ExitFullscreenIcon.tsx
@@ -1,0 +1,20 @@
+import { LsdIcon } from '@acid-info/lsd-react'
+
+export const ExitFullscreenIcon = LsdIcon(
+  (props) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path
+        fill={props.fill || 'white'}
+        d="M 8 19 L 8 16 L 5 16 L 5 14 L 10 14 L 10 19 Z M 14 19 L 14 14 L 19 14 L 19 16 L 16 16 L 16 19 Z M 5 10 L 5 8 L 8 8 L 8 5 L 10 5 L 10 10 Z M 14 10 L 14 5 L 16 5 L 16 8 L 19 8 L 19 10 Z M 14 10 "
+      />
+    </svg>
+  ),
+  { filled: true },
+)

--- a/src/components/Icons/ExitFullscreenIcon/index.ts
+++ b/src/components/Icons/ExitFullscreenIcon/index.ts
@@ -1,0 +1,1 @@
+export * from './ExitFullscreenIcon'

--- a/src/components/Icons/FullscreenIcon/FullscreenIcon.tsx
+++ b/src/components/Icons/FullscreenIcon/FullscreenIcon.tsx
@@ -10,17 +10,10 @@ export const FullscreenIcon = LsdIcon(
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <g clip-path="url(#clip0_2418_8608)">
-        <path
-          d="M4 18C4 19.1 4.9 20 6 20H10V18H6V14H4V18ZM20 6C20 4.9 19.1 4 18 4H14V6H18V10H20V6ZM6 6H10V4H6C4.9 4 4 4.9 4 6V10H6V6ZM20 18V14H18V18H14V20H18C19.1 20 20 19.1 20 18Z"
-          fill={props.fill || 'white'}
-        />
-      </g>
-      <defs>
-        <clipPath id="clip0_2418_8608">
-          <rect width="24" height="24" fill="white" />
-        </clipPath>
-      </defs>
+      <path
+        d="M4 18C4 19.1 4.9 20 6 20H10V18H6V14H4V18ZM20 6C20 4.9 19.1 4 18 4H14V6H18V10H20V6ZM6 6H10V4H6C4.9 4 4 4.9 4 6V10H6V6ZM20 18V14H18V18H14V20H18C19.1 20 20 19.1 20 18Z"
+        fill={props.fill || 'white'}
+      />
     </svg>
   ),
   { filled: true },

--- a/src/components/Icons/FullscreenIcon/FullscreenIcon.tsx
+++ b/src/components/Icons/FullscreenIcon/FullscreenIcon.tsx
@@ -12,7 +12,7 @@ export const FullscreenIcon = LsdIcon(
     >
       <path
         d="M4 18C4 19.1 4.9 20 6 20H10V18H6V14H4V18ZM20 6C20 4.9 19.1 4 18 4H14V6H18V10H20V6ZM6 6H10V4H6C4.9 4 4 4.9 4 6V10H6V6ZM20 18V14H18V18H14V20H18C19.1 20 20 19.1 20 18Z"
-        fill={props.fill || 'white'}
+        fill="white"
       />
     </svg>
   ),

--- a/src/components/LightBox/LightBox.tsx
+++ b/src/components/LightBox/LightBox.tsx
@@ -1,0 +1,232 @@
+import { lsdUtils } from '@/utils/lsd.utils'
+import { useIsMobile } from '@/utils/ui.utils'
+import { IconButton } from '@acid-info/lsd-react'
+import styled from '@emotion/styled'
+import React, {
+  CSSProperties,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import QuickPinchZoom, { make3dTransformValue } from 'react-quick-pinch-zoom'
+import { useWindowScroll } from 'react-use'
+import { ExitFullscreenIcon } from '../Icons/ExitFullscreenIcon'
+import { FullscreenIcon } from '../Icons/FullscreenIcon'
+import { HEADER_HEIGHT_PX } from '../NavBar/NavBar'
+
+type UseLightBoxReturnType = {
+  getStyle: (element: HTMLElement | null) => React.CSSProperties
+  close: () => void
+  display: (element: HTMLElement) => void
+  isDisplayedElement: (el: HTMLElement) => boolean
+  isActive: boolean
+  isMobile: boolean
+}
+
+// Main logic was taken from:
+// https://github.com/acid-info/logos-docusaurus-plugins/blob/964bf92263cf6eb61527c92c83c73ab6ba74e36d/packages/logos-docusaurus-theme/src/client/containers/LightBox/LightBox.tsx
+export const useLightBox = (): UseLightBoxReturnType => {
+  const { y: scrollY } = useWindowScroll()
+  const [displayedElement, setDisplayedElement] = useState<HTMLElement | null>(
+    null,
+  )
+  const [displayedStyle, setDisplayedStyle] = useState<CSSProperties>({
+    opacity: '0.5',
+  })
+  const isMobile = useIsMobile()
+
+  const defaultStyle: CSSProperties = {
+    opacity: 1,
+    transform: 'scale(1) translate(0px, 0px)',
+    transition: 'all 0.3s ease-in-out',
+  }
+
+  const display = (element: HTMLElement) => {
+    setDisplayedElement(element)
+
+    const vw = document.body.clientWidth
+    const vh = window.innerHeight
+
+    const maxWidth = isMobile ? vw - 32 : vw * 0.9375
+    const maxHeight = vh - 128
+
+    const rect = element.getBoundingClientRect()
+
+    const scale = Math.min(maxHeight / rect.height, maxWidth / rect.width)
+
+    const center = [rect.left + rect.width / 2, rect.top + rect.height / 2]
+    const windowCenter = [vw / 2, vh / 2]
+
+    const translate = windowCenter.map((w, i) => (w - center[i]!) / scale)
+
+    setDisplayedStyle({
+      zIndex: 202,
+      transform: `scale(${scale}) translate(${translate[0]}px, ${translate[1]}px)`,
+      position: 'relative',
+    })
+  }
+
+  const close = () => {
+    setDisplayedElement(null)
+  }
+
+  // If the user scrolls, close the lightbox.
+  useEffect(() => {
+    // On mobile, this is not needed: even if the user attempts to scroll, lightbox stays open.
+    if (isMobile) return
+
+    if (displayedElement) close()
+  }, [scrollY])
+
+  // Only for mobile - toggle the whole page's overflow when the lightbox is displayed.
+  useEffect(() => {
+    const html = document.querySelector('html')!
+    html.style.overflow = isMobile && displayedElement ? 'hidden' : 'initial'
+  }, [isMobile, displayedElement])
+
+  return {
+    getStyle: (element: HTMLElement | null) => ({
+      ...defaultStyle,
+      ...(element === displayedElement ? displayedStyle : {}),
+    }),
+    close,
+    display,
+    isDisplayedElement: (el: HTMLElement) => displayedElement === el,
+    isActive: !!displayedElement,
+    isMobile,
+  }
+}
+
+type OnUpdateParams = {
+  x: number
+  y: number
+  scale: number
+}
+
+type LightBoxProps = {
+  children: React.ReactNode
+}
+
+export const LightBox = ({ children }: LightBoxProps) => {
+  const { getStyle, display, isDisplayedElement, isActive, close, isMobile } =
+    useLightBox()
+  const ref = useRef<HTMLDivElement>(null)
+  const childRef = useRef<HTMLDivElement>(null)
+
+  const handleUpdate = useCallback(({ x, y, scale }: OnUpdateParams) => {
+    const img = childRef.current
+    if (img) {
+      const transformValue = make3dTransformValue({ x, y, scale })
+      img.style.transform = transformValue
+    }
+  }, [])
+
+  const lightBoxContent =
+    isMobile && ref.current && isDisplayedElement(ref.current) ? (
+      <QuickPinchZoom
+        onUpdate={handleUpdate}
+        doubleTapZoomOutOnMaxScale
+        maxZoom={3}
+      >
+        <div ref={childRef}>{children}</div>
+      </QuickPinchZoom>
+    ) : (
+      <>
+        {children}
+
+        <FullscreenIconButton
+          size="medium"
+          className={isActive ? '' : 'fullscreen-button'}
+          onClick={() => display(ref.current!)}
+        >
+          <FullscreenIcon color="primary" width="16" height="16" />
+        </FullscreenIconButton>
+      </>
+    )
+
+  return (
+    <>
+      {isActive && (
+        // When the lighbox is active: show a backdrop, and a header with an ExitFullscreenIcon.
+        <>
+          <Backdrop />
+
+          <Header>
+            <ExitFullscreenIconButton size="small" onClick={() => close()}>
+              <ExitFullscreenIcon color="primary" width="18" height="18" />
+            </ExitFullscreenIconButton>
+          </Header>
+        </>
+      )}
+
+      <LightboxMediaContainer ref={ref} style={getStyle(ref.current)}>
+        {lightBoxContent}
+      </LightboxMediaContainer>
+    </>
+  )
+}
+
+const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgb(var(--lsd-surface-primary));
+  z-index: 201;
+  opacity: 1;
+`
+
+const FullscreenIconButton = styled(IconButton)`
+  display: flex;
+  transition: opacity 0.4s;
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background-color: rgb(var(--lsd-text-secondary));
+
+  ${(props) => lsdUtils.breakpoint(props.theme, 'sm', 'up')} {
+    // If we're not in mobile mode, hide the button. Only show it when hovering over the container.
+    opacity: 0;
+    pointer-events: none;
+  }
+`
+
+const ExitFullscreenIconButton = styled(IconButton)`
+  margin-right: 16px;
+`
+
+const LightboxMediaContainer = styled.div`
+  // Show the fullscreen button when users hover over the container.
+  &:hover .fullscreen-button {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  // The following allows for greater mobile pinch zoom.
+  ${(props) => lsdUtils.breakpoint(props.theme, 'lg', 'down')} {
+    & > div {
+      overflow: visible !important;
+    }
+  }
+`
+
+export const Header = styled.header`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-shrink: 0;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: ${HEADER_HEIGHT_PX};
+
+  z-index: 1000;
+
+  background-color: rgb(var(--lsd-surface-primary));
+  transition: top 0.2s;
+`

--- a/src/components/LightBox/LightBox.tsx
+++ b/src/components/LightBox/LightBox.tsx
@@ -1,5 +1,6 @@
+import { uiConfigs } from '@/configs/ui.configs'
 import { lsdUtils } from '@/utils/lsd.utils'
-import { useIsMobile } from '@/utils/ui.utils'
+import { useIsMobile, useOnWindowResize } from '@/utils/ui.utils'
 import { IconButton } from '@acid-info/lsd-react'
 import styled from '@emotion/styled'
 import React, {
@@ -13,7 +14,6 @@ import QuickPinchZoom, { make3dTransformValue } from 'react-quick-pinch-zoom'
 import { useWindowScroll } from 'react-use'
 import { ExitFullscreenIcon } from '../Icons/ExitFullscreenIcon'
 import { FullscreenIcon } from '../Icons/FullscreenIcon'
-import { HEADER_HEIGHT_PX } from '../NavBar/NavBar'
 
 type UseLightBoxReturnType = {
   getStyle: (element: HTMLElement | null) => React.CSSProperties
@@ -67,9 +67,12 @@ export const useLightBox = (): UseLightBoxReturnType => {
     })
   }
 
-  const close = () => {
+  const close = useCallback(() => {
     setDisplayedElement(null)
-  }
+  }, [])
+
+  // When the window is resized, close the lightbox.
+  useOnWindowResize(close)
 
   // If the user scrolls, close the lightbox.
   useEffect(() => {
@@ -236,7 +239,7 @@ export const Header = styled.header`
   left: 0;
 
   width: 100%;
-  height: ${HEADER_HEIGHT_PX};
+  height: ${uiConfigs.navbarRenderedHeight - 1}px;
 
   z-index: 1000;
 

--- a/src/components/LightBox/LightBox.tsx
+++ b/src/components/LightBox/LightBox.tsx
@@ -160,7 +160,11 @@ export const LightBox = ({ children }: LightBoxProps) => {
         </>
       )}
 
-      <LightboxMediaContainer ref={ref} style={getStyle(ref.current)}>
+      <LightboxMediaContainer
+        ref={ref}
+        style={getStyle(ref.current)}
+        isActive={isActive}
+      >
         {lightBoxContent}
       </LightboxMediaContainer>
     </>
@@ -197,7 +201,7 @@ const ExitFullscreenIconButton = styled(IconButton)`
   margin-right: 16px;
 `
 
-const LightboxMediaContainer = styled.div`
+const LightboxMediaContainer = styled.div<{ isActive?: boolean }>`
   // Show the fullscreen button when users hover over the container.
   &:hover .fullscreen-button {
     opacity: 1;
@@ -210,6 +214,15 @@ const LightboxMediaContainer = styled.div`
       overflow: visible !important;
     }
   }
+
+  // When the lightbox is active and showing media - removes any filters from said media.
+  ${(props) =>
+    props.isActive &&
+    `
+  div {
+    filter: none;
+  }
+`}
 `
 
 export const Header = styled.header`

--- a/src/components/LightBox/index.ts
+++ b/src/components/LightBox/index.ts
@@ -1,0 +1,1 @@
+export * from './LightBox'

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -21,8 +21,6 @@ import { NavbarState, useNavbarState } from '../../states/navbarState'
 import { lsdUtils } from '../../utils/lsd.utils'
 import { LogosIcon } from '../Icons/LogosIcon'
 
-export const HEADER_HEIGHT_PX = '44px'
-
 export interface NavBarProps {
   defaultState?: Partial<NavbarState>
 }
@@ -127,7 +125,7 @@ const Container = styled.header<{
   bordered?: boolean
 }>`
   width: 100%;
-  height: ${HEADER_HEIGHT_PX};
+  height: 44px;
 
   position: fixed;
   top: 0;

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -123,7 +123,7 @@ const SocialMediaKitContainer = styled.div`
   }
 `
 
-export const Container = styled.header<{
+const Container = styled.header<{
   bordered?: boolean
 }>`
   width: 100%;

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -21,6 +21,8 @@ import { NavbarState, useNavbarState } from '../../states/navbarState'
 import { lsdUtils } from '../../utils/lsd.utils'
 import { LogosIcon } from '../Icons/LogosIcon'
 
+export const HEADER_HEIGHT_PX = '44px'
+
 export interface NavBarProps {
   defaultState?: Partial<NavbarState>
 }
@@ -121,11 +123,11 @@ const SocialMediaKitContainer = styled.div`
   }
 `
 
-const Container = styled.header<{
+export const Container = styled.header<{
   bordered?: boolean
 }>`
   width: 100%;
-  height: 44px;
+  height: ${HEADER_HEIGHT_PX};
 
   position: fixed;
   top: 0;

--- a/src/utils/ui.utils.ts
+++ b/src/utils/ui.utils.ts
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react'
 import React, {
   MutableRefObject,
   RefObject,
@@ -149,6 +150,15 @@ export const useScrollDirection = () => {
   }, [lastScrollTop])
 
   return scrollDirection
+}
+
+export const useIsMobile = () => {
+  const theme = useTheme()
+  const windowSize = useWindowSize()
+
+  const smWidth = theme.breakpoints.sm.width
+
+  return windowSize.width < smWidth
 }
 
 export default useWindowSize

--- a/src/utils/ui.utils.ts
+++ b/src/utils/ui.utils.ts
@@ -161,4 +161,14 @@ export const useIsMobile = () => {
   return windowSize.width < smWidth
 }
 
+export const useOnWindowResize = (callback: () => void): void => {
+  useEffect(() => {
+    window.addEventListener('resize', callback)
+
+    return () => {
+      window.removeEventListener('resize', callback)
+    }
+  }, [callback])
+}
+
 export default useWindowSize

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,6 +4831,13 @@ react-player@^2.12.0:
     prop-types "^15.7.2"
     react-fast-compare "^3.0.1"
 
+react-quick-pinch-zoom@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/react-quick-pinch-zoom/-/react-quick-pinch-zoom-4.9.0.tgz#13d91adb7ea2e75c5a2ff43d71d2a0e04a56cf62"
+  integrity sha512-gCPnZu5+rkYDNvewi/d7A2wgLs7izQNMuC6kjt+KLC1qqHnRU27Ed8AgcEcnWAZKdMr3ZKoKhSvjlZSVZI0fuw==
+  dependencies:
+    tslib ">=2.0.0"
+
 react-universal-interface@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
@@ -5557,6 +5564,11 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@>=2.0.0, tslib@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -5571,11 +5583,6 @@ tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
-
-tslib@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@~2.5.0:
   version "2.5.3"


### PR DESCRIPTION
Creates a basic version of the LightBox component for all images in an LPE article. 

It was heavily inspired by:
https://github.com/acid-info/logos-docusaurus-plugins/blob/964bf92263cf6eb61527c92c83c73ab6ba74e36d/packages/logos-docusaurus-theme/src/client/containers/LightBox/LightBox.tsx

The main differences are:
    - Here, we have both dark and light mode.
    - The headers are different.
    - Looks like the logic to determine isMobile is different between vac.dev and LPE.
    - The breakpoint values are a little bit different.
    - The images here have a gray filter. When enlarging them, I remove the filter (this was a decision I made, happy to change)

### Video 1 - desktop:

https://github.com/acid-info/logos-press-engine/assets/9993816/afc8bab7-2002-414f-9f5d-c7086deb95c6

### Video 2 - mobile with pinch zoom:

https://github.com/acid-info/logos-press-engine/assets/9993816/1c5d2bfd-e18c-4e3b-8161-49dbd16084e3
