### PR TITLE
Adds "by" label next to author names

### DIFF
--- a/src/components/Authors/Authors.tsx
+++ b/src/components/Authors/Authors.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@acid-info/lsd-react'
 import styled from '@emotion/styled'
 import { LPE } from '../../types/lpe.types'
 import { DotIcon } from '../Icons/DotIcon'
@@ -24,6 +25,9 @@ const Authors: React.FC<AuthorsProps> = ({
 }) => {
   return authors?.length > 0 ? (
     <AuthorsContainer gap={gap} flexDirection={flexDirection} {...props}>
+      <Typography variant="label2" style={{ marginRight: `${3 - gap}px` }}>
+        by
+      </Typography>
       {authors.map((author, index) => (
         <AuthorContainer gap={gap} key={author.name}>
           <Author author={author} email={email} />


### PR DESCRIPTION
### Description:
Adds "by" label next to author names

### Related Issue(s):
https://github.com/acid-info/logos-press-engine/issues/205

### Changes Included:
- [ ] Bugfix (a change that fixes an issue)
- [X] New feature (a change that adds new functionality)
- [ ] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:
The distance between the "by" label and the 1st author's name is fixed. But it needs to take the gap into account. So, if the distance is 3 and the gap is 12, the margin-right of the "by" label will be: 3 - 12

### Testing:
Checked out the main page, articles, and related article section.

### Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Single author:

![Screenshot from 2023-10-20 13-49-47](https://github.com/acid-info/logos-press-engine/assets/9993816/643295b0-60c6-4331-882c-099e52d3d3f5)

![Screenshot from 2023-10-20 13-50-08](https://github.com/acid-info/logos-press-engine/assets/9993816/e94ff804-1162-4d48-8206-d3d6d83b01f6)

![Screenshot from 2023-10-20 13-50-29](https://github.com/acid-info/logos-press-engine/assets/9993816/2c98fca4-04e8-4f51-af99-77941c800d7f)

# Multiple authors:

![Screenshot from 2023-10-20 13-52-27](https://github.com/acid-info/logos-press-engine/assets/9993816/1839b73f-435c-40c8-8535-f2ab0e66534a)

![Screenshot from 2023-10-20 13-52-46](https://github.com/acid-info/logos-press-engine/assets/9993816/951bc930-83a1-4395-9bee-61f7e4db98fb)

![Screenshot from 2023-10-20 13-53-17](https://github.com/acid-info/logos-press-engine/assets/9993816/e0f7c214-5efa-4dc9-8786-45451fe0fcb3)
