### PR TITLE
Newsletter subscription - change "To home page" link to just a button that closes the dialog

### DIFF
--- a/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
+++ b/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
@@ -6,7 +6,6 @@ import {
   Typography,
 } from '@acid-info/lsd-react'
 import styled from '@emotion/styled'
-import Link from 'next/link'
 
 type NewsletterSubscriptionFormProps = React.HTMLAttributes<HTMLDivElement> & {
   handleFormSubmit: (e: React.FormEvent<HTMLFormElement>) => void
@@ -44,9 +43,9 @@ export default function NewsletterSubscriptionForm({
               {successMessage}
             </SubmitionInfoMessage>
           </MessageContainer>
-          <Link href="/" onClick={onClose}>
-            <ToHomePageButton variant="filled">To home page</ToHomePageButton>
-          </Link>
+          <ToHomePageButton variant="filled" onClick={onClose}>
+            Go back
+          </ToHomePageButton>
         </>
       )}
 


### PR DESCRIPTION
### Description:
On the newsletter subscription dialog, changes "To home page" link to a "Go back" button that closes the dialog

### Related Issue(s):
(none)

### Changes Included:
- [ ] Bugfix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [X] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:
It's a pretty simple change. Describing it here would be harder than actually implementing it.

### Testing:
We can use the `successtest@successtest.com` email to trigger the success state. The "Go back" button should simply close the dialog.

### Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules