### PR TITLE
Improve mobile styles for the subscription dialog

### DIFF
--- a/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -69,7 +69,6 @@ const MainContentContainer = styled.div`
 
 const FullscreenDialogContainer = styled.div`
   position: fixed;
-
   top: 0;
   left: 0;
   width: 100vw;

--- a/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -50,6 +50,11 @@ const MainContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  /* safe center will center for large screens, but still show a scroll bar for smaller screens */
+  justify-content: safe center;
+
+  overflow: auto;
+  height: 100%;
 
   padding: 24px 0;
   width: 430px;
@@ -64,6 +69,7 @@ const MainContentContainer = styled.div`
 
 const FullscreenDialogContainer = styled.div`
   position: fixed;
+
   top: 0;
   left: 0;
   width: 100vw;

--- a/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
+++ b/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
@@ -43,9 +43,9 @@ export default function NewsletterSubscriptionForm({
               {successMessage}
             </SubmitionInfoMessage>
           </MessageContainer>
-          <ToHomePageButton variant="filled" onClick={onClose}>
+          <GoBackButton variant="filled" onClick={onClose}>
             Go back
-          </ToHomePageButton>
+          </GoBackButton>
         </>
       )}
 
@@ -92,8 +92,9 @@ export default function NewsletterSubscriptionForm({
   )
 }
 
-const ToHomePageButton = styled(Button)`
+const GoBackButton = styled(Button)`
   margin-top: 46px;
+  margin-bottom: 60px;
   height: 40px;
   width: 162px;
   color: rgb(var(--lsd-text-secondary));
@@ -129,7 +130,7 @@ const EmailSubscribeForm = styled.form<{
   width: 100%;
   margin-top: 50px;
 
-  margin-bottom: 30px;
+  margin-bottom: 60px;
 `
 
 const StyledTextField = styled(TextField)`

--- a/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
+++ b/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
@@ -128,6 +128,8 @@ const EmailSubscribeForm = styled.form<{
   gap: 16px;
   width: 100%;
   margin-top: 50px;
+
+  margin-bottom: 30px;
 `
 
 const StyledTextField = styled(TextField)`

--- a/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
+++ b/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
@@ -101,6 +101,8 @@ const GoBackButton = styled(Button)`
 `
 
 const MessageContainer = styled.div`
+  box-sizing: border-box;
+
   display: flex;
   align-items: center;
 
@@ -110,8 +112,11 @@ const MessageContainer = styled.div`
   margin-bottom: -6px;
   margin-top: 40px;
 
-  width: 430px;
-  max-width: 93%;
+  width: 100%;
+
+  svg {
+    flex-shrink: 0;
+  }
 `
 
 const SubmitionInfoMessage = styled(Typography)`

--- a/src/containers/NewsletterSubscriptionDialog/NewsletterSubscriptionDialog.tsx
+++ b/src/containers/NewsletterSubscriptionDialog/NewsletterSubscriptionDialog.tsx
@@ -112,5 +112,6 @@ const LogosIconAndTitleContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 16px;
+
+  margin: 16px 0;
 `


### PR DESCRIPTION
### Description:
Improve mobile styles for the subscription dialog. Previsouly, for mobile phones in landscape mode, the modal was cut off with no scroll bar:

[Screencast from 26-10-2023 19:11:40.webm](https://github.com/acid-info/logos-press-engine/assets/9993816/42d1a3ac-4c58-4d5d-8e9b-c4728a15d89d)

Now, a scroll bar is shown and the content is no longer cut off:
 
[Screencast from 26-10-2023 19:10:40.webm](https://github.com/acid-info/logos-press-engine/assets/9993816/2f6cb549-1892-443f-9ef0-0cea460a84d2)


### Related Issue(s):
(none)

### Changes Included:
- [X] Bugfix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:
Used the following:

- height: 100%; without this, there is no overflow - if this is not present, the height will be exactly the same as the viewport - meaning scroll bars won't show, and content will be cut off
- overflow: auto; to enable a scrollbar
- justify-content: safe center; in small screens, the `safe` keyword will not `center` the content, but display it as `flex-start` (meaning there's no cutting off / data loss)

### Testing:
We can try to emulate landscape on the browser, and checking out the newsletter subscription dialog

### Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules