### PR TITLE
Newsletter Subscription Dialog - Add a container to the close button

### DIFF
--- a/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -34,18 +34,18 @@ export default function FullscreenDialog({
   return (
     <FullscreenDialogContainer {...props}>
       <MainContentContainer>
-        <CloseIconContainer>
+        <CloseButtonContainer>
           <IconButton size="small" onClick={() => onClose()}>
             <CloseIcon color="primary" />
           </IconButton>
-        </CloseIconContainer>
+        </CloseButtonContainer>
         {children}
       </MainContentContainer>
     </FullscreenDialogContainer>
   )
 }
 
-const CloseIconContainer = styled.div`
+const CloseButtonContainer = styled.div`
   position: fixed;
   top: 8px;
   width: ${uiConfigs.maxContainerWidth}px;

--- a/src/components/FullscreenDialog/FullscreenDialog.tsx
+++ b/src/components/FullscreenDialog/FullscreenDialog.tsx
@@ -1,3 +1,4 @@
+import { uiConfigs } from '@/configs/ui.configs'
 import { CloseIcon, IconButton } from '@acid-info/lsd-react'
 import styled from '@emotion/styled'
 import { useEffect } from 'react'
@@ -33,18 +34,26 @@ export default function FullscreenDialog({
   return (
     <FullscreenDialogContainer {...props}>
       <MainContentContainer>
-        <IconButton
-          className="fullscreen-dialog__close-button"
-          size="small"
-          onClick={() => onClose()}
-        >
-          <CloseIcon color="primary" />
-        </IconButton>
+        <CloseIconContainer>
+          <IconButton size="small" onClick={() => onClose()}>
+            <CloseIcon color="primary" />
+          </IconButton>
+        </CloseIconContainer>
         {children}
       </MainContentContainer>
     </FullscreenDialogContainer>
   )
 }
+
+const CloseIconContainer = styled.div`
+  position: fixed;
+  top: 8px;
+  width: ${uiConfigs.maxContainerWidth}px;
+  max-width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 30px;
+`
 
 const MainContentContainer = styled.div`
   display: flex;
@@ -56,15 +65,8 @@ const MainContentContainer = styled.div`
   overflow: auto;
   height: 100%;
 
-  padding: 24px 0;
-  width: 430px;
-  max-width: 90%;
-
-  .fullscreen-dialog__close-button {
-    position: absolute;
-    top: 8px;
-    right: 30px;
-  }
+  width: ${uiConfigs.maxContainerWidth}px;
+  max-width: 100%;
 `
 
 const FullscreenDialogContainer = styled.div`

--- a/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
+++ b/src/components/NewsletterSubscriptionForm/NewsletterSubscriptionForm.tsx
@@ -25,7 +25,7 @@ export default function NewsletterSubscriptionForm({
   const disabled = isSubmitting
 
   return (
-    <>
+    <FormContainer>
       {errorMessage && (
         <MessageContainer>
           <ErrorIcon color="primary" />
@@ -88,9 +88,15 @@ export default function NewsletterSubscriptionForm({
           {isSubmitting ? 'Subscribing...' : 'Subscribe'}
         </SubscribeButton>
       </EmailSubscribeForm>
-    </>
+    </FormContainer>
   )
 }
+
+const FormContainer = styled.div`
+  padding: 24px 0;
+  width: 430px;
+  max-width: 90%;
+`
 
 const GoBackButton = styled(Button)`
   margin-top: 46px;


### PR DESCRIPTION
### Description:
Adds a container to the close button. Now, the close button won't show beyond the 1440px container.

# Before:

![Screenshot from 2023-10-27 12-30-18](https://github.com/acid-info/logos-press-engine/assets/9993816/8405f0e9-d90b-4f2a-a3fa-01d2b232893d)

# After:

![Screenshot from 2023-10-27 12-29-51](https://github.com/acid-info/logos-press-engine/assets/9993816/d8cbfe07-0cf8-4573-bbf8-ba7a74f49535)


### Related Issue(s):
(none)

### Changes Included:
- [X] Bugfix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Refactoring (a change that improves code quality and/or architecture)
- [ ] Other (explain below)

### Implementation Details:
Added a container to the close icon. The size logic in the fullscreen dialog was also updated - it now defaults to the uiConfigs maxContainerWidth - and the passed in child components should define their own size.

### Testing:
Zoom out and see where the close button is.

### Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules