### PR TITLE
Enhance Open Graph image generation with improved article layout

### DIFF
--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -147,20 +147,40 @@ export default async function handler(request: NextRequest) {
                 fontSize: titleFontSize,
                 lineHeight: '115%',
                 whiteSpace: 'pre-wrap',
+                width: '100%',
               }}
             >
-              {title && title.length < titleMaxLength
-                ? title
-                : title?.substring(0, titleMaxLength) + '...'}
+              <span
+                style={{
+                  background:
+                    'linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.3) 100%)',
+                  padding: '12px 16px',
+                  borderRadius: '4px',
+                  textShadow: '0 2px 4px rgba(0,0,0,0.5)',
+                  color: '#fff',
+                  display: 'block',
+                  width: '100%',
+                }}
+              >
+                {title && title.length < titleMaxLength
+                  ? title
+                  : title?.substring(0, titleMaxLength) + '...'}
+              </span>
             </div>
             <div
               style={{
                 display: 'flex',
                 gap: subtitleGap,
                 fontSize: subtitleFontSize,
+                textShadow: '0 2px 4px rgba(0,0,0,0.5)',
                 alignItems: 'center',
                 textTransform: 'capitalize',
                 fontFamily: 'Inter',
+                background:
+                  'linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.3) 100%)',
+                padding: '12px 16px',
+                borderRadius: '4px',
+                width: '100%',
               }}
             >
               <span>


### PR DESCRIPTION
## Previous
- [Link preview for https://press.logos.co/article/november-2025](https://press.logos.co/api/og?q=title%253DState%252Bof%252Bthe%252BLogos%252BNetwork%25253A%252BNovember%252B2025%2526image%253Dhttps%25253A%25252F%25252Fcms-press.logos.co%25252Fuploads%25252Flogos_november_update_featured_39596bcb52.png%2526contentType%253Darticle%2526date%253D2025-12-08%2526pagePath%253D%25252Farticle%25252Fnovember-2025%2526authors%253DLogos)

<img width="1189" height="616" alt="Screenshot 2025-12-11 at 12 43 10 AM" src="https://github.com/user-attachments/assets/332e3ee2-a319-4570-b965-f1e7e1a1ea36" />

## Updated
- [Link preview for https://press.logos.co/article/november-2025](https://lpe-git-og-image-acidinfo.vercel.app/api/og?q=title%253DState%252Bof%252Bthe%252BLogos%252BNetwork%25253A%252BNovember%252B2025%2526image%253Dhttps%25253A%25252F%25252Fcms-press.logos.co%25252Fuploads%25252Flogos_november_update_featured_39596bcb52.png%2526contentType%253Darticle%2526date%253D2025-12-08%2526pagePath%253D%25252Farticle%25252Fnovember-2025%2526authors%253DLogos)
<img width="1195" height="609" alt="Screenshot 2025-12-11 at 12 44 09 AM" src="https://github.com/user-attachments/assets/f1d6d9e2-68d8-4e2f-9256-8ce88b8563bd" />

## Relevant discord thread
https://discord.com/channels/864066763682218004/1448286060672057416/1448291402331983973