### PR TITLE
Pre-generate OG images as JPEG via Strapi lifecycle and serve static URLs

### DIFF
--- a/src/components/Article/Footer/Article.Footer.tsx
+++ b/src/components/Article/Footer/Article.Footer.tsx
@@ -35,8 +35,8 @@ const ArticleFooter = ({ data: post }: { data: LPE.Article.Document }) => {
 const ArticleFooterContainer = styled.div`
   margin-top: 16px;
 
-  & > div:not(:first-child):not([data-keep-border-top='true']) > div > button,
-  & > div:not(:first-child):not([data-keep-border-top='true']) > div {
+  & > div:not(:first-of-type):not([data-keep-border-top='true']) > div > button,
+  & > div:not(:first-of-type):not([data-keep-border-top='true']) > div {
     border-top: none;
   }
 

--- a/src/components/Episode/Footer/Episode.Footer.tsx
+++ b/src/components/Episode/Footer/Episode.Footer.tsx
@@ -38,8 +38,8 @@ const EpisodeFooter = ({ episode, relatedEpisodes }: Props) => {
 const EpisodeFooterContainer = styled.div`
   margin-top: 56px;
 
-  & > div:not(:first-child) > div > button,
-  & > div:not(:first-child) > div {
+  & > div:not(:first-of-type) > div > button,
+  & > div:not(:first-of-type) > div {
     border-top: none;
   }
 

--- a/src/components/Podcasts/Podcast.Section.tsx
+++ b/src/components/Podcasts/Podcast.Section.tsx
@@ -13,7 +13,7 @@ export const PodcastSection: React.FC<PodcastSectionProps> = ({
 )
 
 const Container = styled.div`
-  & > *:not(:first-child) {
+  & > *:not(:first-of-type) {
     margin-top: var(--lsd-spacing-16);
   }
 

--- a/src/components/Podcasts/Podcasts.Lists.tsx
+++ b/src/components/Podcasts/Podcasts.Lists.tsx
@@ -40,7 +40,7 @@ export default function PodcastsLists({ shows }: Props) {
                       </ShowInfo>
                     </ShowInfoContainer>
                   </Top>
-                  <ShowData isEven={isEven}>
+                  <ShowData $isEven={isEven}>
                     <Description
                       variant="h4"
                       dangerouslySetInnerHTML={{ __html: show.description }}
@@ -75,7 +75,9 @@ const PodcastListsContainer = styled(Grid)`
 
 const ShowCardContainer = styled(GridItem)``
 
-const ShowCard = styled(Link)<{ isEven: boolean }>`
+const ShowCard = styled(Link, {
+  shouldForwardProp: (prop) => prop !== 'isEven',
+})<{ isEven: boolean }>`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -120,7 +122,7 @@ const Top = styled(Row)`
   justify-content: space-between;
 `
 
-const ShowData = styled.div<{ isEven: boolean }>`
+const ShowData = styled.div<{ $isEven: boolean }>`
   margin-top: 24px;
   display: flex;
   flex-direction: column;
@@ -129,7 +131,7 @@ const ShowData = styled.div<{ isEven: boolean }>`
   p,
   span {
     color: ${(props) =>
-      props.isEven
+      props.$isEven
         ? 'rgb(var(--lsd-text-secondary))'
         : 'rgb(var(--lsd-text-primary))'};
   }
@@ -139,7 +141,9 @@ const ShowData = styled.div<{ isEven: boolean }>`
   }
 `
 
-const ColoredText = styled(Typography)<{ isEven: boolean }>`
+const ColoredText = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'isEven',
+})<{ isEven: boolean }>`
   color: ${(props) =>
     props.isEven
       ? 'rgb(var(--lsd-text-secondary))'
@@ -152,7 +156,9 @@ const Description = styled(Typography)`
   }
 `
 
-const ShowButton = styled(Button)<{ isEven: boolean }>`
+const ShowButton = styled(Button, {
+  shouldForwardProp: (prop) => prop !== 'isEven',
+})<{ isEven: boolean }>`
   width: auto;
   align-self: flex-start;
 

--- a/src/components/SEO/SEO.tsx
+++ b/src/components/SEO/SEO.tsx
@@ -13,6 +13,12 @@ type Metadata = {
   pageURL?: string
   imageUrl?: string
   image?: LPE.Image.Document | null
+  /**
+   * Pre-generated OG image stored in the CMS. When present, takes
+   * precedence over dynamic /api/og rendering so Twitterbot never
+   * has to hit the slow WASM code path.
+   */
+  ogImage?: LPE.Image.Document | null
   tags?: string[]
   pagePath?: string
   date?: string | null
@@ -33,6 +39,7 @@ export default function SEO({
   pageURL,
   imageUrl,
   image,
+  ogImage,
   tags = siteConfigs.keywords,
   pagePath = '',
   date,
@@ -47,7 +54,12 @@ export default function SEO({
       : siteConfigs.title
   const description = _description || siteConfigs.description
 
+  // Preference order:
+  //   1) Pre-generated og_image stored in the CMS (static JPG, fastest for scrapers).
+  //   2) Explicit imageUrl prop override (callers can force a URL).
+  //   3) Dynamic /api/og fallback for legacy content without og_image.
   const ogImageUrl =
+    ogImage?.url ||
     imageUrl ||
     getOpenGraphImageUrl({
       title: _title,

--- a/src/components/SEO/SEO.tsx
+++ b/src/components/SEO/SEO.tsx
@@ -13,11 +13,6 @@ type Metadata = {
   pageURL?: string
   imageUrl?: string
   image?: LPE.Image.Document | null
-  /**
-   * Pre-generated OG image stored in the CMS. When present, takes
-   * precedence over dynamic /api/og rendering so Twitterbot never
-   * has to hit the slow WASM code path.
-   */
   ogImage?: LPE.Image.Document | null
   tags?: string[]
   pagePath?: string
@@ -55,9 +50,9 @@ export default function SEO({
   const description = _description || siteConfigs.description
 
   // Preference order:
-  //   1) Pre-generated og_image stored in the CMS (static JPG, fastest for scrapers).
-  //   2) Explicit imageUrl prop override (callers can force a URL).
-  //   3) Dynamic /api/og fallback for legacy content without og_image.
+  //  1) Pre-generated og_image stored in the CMS (static JPG)
+  //  2) Explicit imageUrl prop override (callers can force a URL)
+  //  3) Dynamic /api/og fallback for legacy content without og_image
   const ogImageUrl =
     ogImage?.url ||
     imageUrl ||

--- a/src/components/SearchBox/SearchBoxFilters.tsx
+++ b/src/components/SearchBox/SearchBoxFilters.tsx
@@ -110,7 +110,7 @@ const Clear = styled(Typography)`
   }
 
   ${(props) => lsdUtils.breakpoint(props.theme, 'xs', 'exact')} {
-    span:not(:first-child) {
+    span:not(:first-of-type) {
       display: none;
     }
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -15,16 +15,29 @@ const transport = isDevelopment
     }
   : undefined
 
-export const logger = pino({
-  level: logLevel,
-  transport,
-  formatters: {
-    level: (label) => ({ level: label.toUpperCase() }),
-  },
-  timestamp: pino.stdTimeFunctions.isoTime,
-  ...(isDevelopment
-    ? {}
-    : { base: { pid: process.pid, hostname: require('os').hostname() } }),
-})
+declare global {
+  // Reuse the logger across Next.js dev hot reloads so transports do not
+  // attach duplicate listeners to stdout/stderr.
+  // eslint-disable-next-line no-var
+  var __lpeLogger__: pino.Logger | undefined
+}
+
+export const logger =
+  global.__lpeLogger__ ||
+  pino({
+    level: logLevel,
+    transport,
+    formatters: {
+      level: (label) => ({ level: label.toUpperCase() }),
+    },
+    timestamp: pino.stdTimeFunctions.isoTime,
+    ...(isDevelopment
+      ? {}
+      : { base: { pid: process.pid, hostname: require('os').hostname() } }),
+  })
+
+if (isDevelopment) {
+  global.__lpeLogger__ = logger
+}
 
 export default logger

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -187,6 +187,10 @@ export default async function handler(
   const subtitleFontSize = isArticle && hasImage ? '26px' : '32px'
   const subtitleGap = isArticle && hasImage ? '16px' : '24px'
   const subtitleMargin = isArticle && hasImage ? '24px' : '40px'
+  const overlayPanelBackground =
+    'linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.3) 100%)'
+  const overlayTextShadow = '0 2px 4px rgba(0,0,0,0.5)'
+  const overlayDropShadow = 'drop-shadow(0 2px 4px rgba(0,0,0,0.5))'
 
   let imageResponse: ImageResponse
 
@@ -241,6 +245,10 @@ export default async function handler(
                 gap: '0',
                 display: 'flex',
                 alignItems: 'center',
+                alignSelf: 'flex-start',
+                background: overlayPanelBackground,
+                padding: '12px 16px',
+                borderRadius: '4px',
               }}
             >
               <svg
@@ -249,7 +257,10 @@ export default async function handler(
                 viewBox="0 0 93 126"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
-                style={{ marginRight: '10px' }}
+                style={{
+                  marginRight: '10px',
+                  filter: overlayDropShadow,
+                }}
               >
                 <path
                   d="M71.2154 126C66.7864 126 62.9754 124.958 59.7824 122.873C56.5894 120.789 54.1688 117.506 52.5208 113.025C51.4908 110.002 50.7698 106.303 50.3578 101.926C49.9458 97.5484 49.6883 92.9628 49.5853 88.1687C49.4823 83.2705 49.3793 78.5285 49.2763 73.9429C49.2763 72.6923 48.9673 72.067 48.3493 72.067C47.8343 72.067 47.3193 72.4839 46.8043 73.3176C44.8473 76.9653 42.5298 81.134 39.8518 85.8238C37.2768 90.5136 34.7018 95.2035 32.1268 99.8933C29.5517 104.583 27.2342 108.804 25.1742 112.556C23.2172 116.203 21.8267 118.861 21.0027 120.529C19.9727 122.821 18.3247 124.28 16.0587 124.906C13.8957 125.635 11.1662 125.792 7.87017 125.375C4.57415 124.958 2.25664 123.655 0.91764 121.466C-0.524366 119.174 -0.266865 116.777 1.69014 114.275C3.02915 112.608 4.93466 110.107 7.40666 106.772C9.87867 103.333 12.6597 99.4764 15.7497 95.2035C18.8397 90.8263 21.9812 86.3449 25.1742 81.7593C28.4702 77.0695 31.5603 72.5881 34.4443 68.3151C37.3283 63.938 39.7488 60.134 41.7058 56.9032C43.7658 53.5682 45.1048 51.1191 45.7228 49.5558C46.3408 48.0968 47.0103 46.4814 47.7313 44.7097C48.4523 42.938 48.8128 41.1141 48.8128 39.2382C48.8128 32.3598 48.1433 27.201 46.8043 23.7618C45.5683 20.2184 43.8688 17.8734 41.7058 16.727C39.6458 15.4764 37.3798 14.8511 34.9078 14.8511C33.0538 14.8511 31.0453 15.2159 28.8822 15.9454C26.8222 16.6749 25.4832 17.3524 24.8652 17.9777C23.7322 19.1241 22.6507 19.3325 21.6207 18.603C20.5907 17.8734 20.2817 16.6749 20.6937 15.0074C21.8267 11.1514 23.8867 7.71216 26.8737 4.68982C29.8608 1.56327 34.0323 0 39.3883 0C45.0533 0 49.5338 1.61539 52.8298 4.84616C56.1259 8.07692 58.4949 13.2357 59.9369 20.3226C61.3789 27.4094 62.0999 36.7891 62.0999 48.4615C62.0999 62.2184 62.3059 73.2134 62.7179 81.4466C63.1299 89.6799 63.7994 95.8809 64.7264 100.05C65.6534 104.114 66.9409 106.824 68.5889 108.179C70.3399 109.534 72.5029 110.211 75.0779 110.211C77.5499 110.211 79.8674 109.69 82.0305 108.648C84.2965 107.605 86.2535 106.251 87.9015 104.583C88.6225 103.749 89.4465 103.437 90.3735 103.645C91.3005 103.854 92.0215 104.427 92.5365 105.365C93.1545 106.199 93.1545 107.293 92.5365 108.648C90.3735 113.442 87.4895 117.558 83.8845 120.998C80.3824 124.333 76.1594 126 71.2154 126Z"
@@ -264,6 +275,7 @@ export default async function handler(
                   whiteSpace: 'pre-wrap',
                   textTransform: 'uppercase',
                   paddingLeft: '3px',
+                  textShadow: overlayTextShadow,
                 }}
               >
                 <span>{siteConfigs.title}</span>
@@ -289,11 +301,10 @@ export default async function handler(
               >
                 <span
                   style={{
-                    background:
-                      'linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.3) 100%)',
+                    background: overlayPanelBackground,
                     padding: '12px 16px',
                     borderRadius: '4px',
-                    textShadow: '0 2px 4px rgba(0,0,0,0.5)',
+                    textShadow: overlayTextShadow,
                     color: '#fff',
                     display: 'block',
                     width: '100%',
@@ -309,12 +320,11 @@ export default async function handler(
                   display: 'flex',
                   gap: subtitleGap,
                   fontSize: subtitleFontSize,
-                  textShadow: '0 2px 4px rgba(0,0,0,0.5)',
+                  textShadow: overlayTextShadow,
                   alignItems: 'center',
                   textTransform: 'capitalize',
                   fontFamily: 'Inter',
-                  background:
-                    'linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0,0,0,0.3) 100%)',
+                  background: overlayPanelBackground,
                   padding: '12px 16px',
                   borderRadius: '4px',
                   width: '100%',
@@ -371,6 +381,10 @@ export default async function handler(
                 gap: '0',
                 display: 'flex',
                 alignItems: 'center',
+                alignSelf: 'flex-start',
+                background: overlayPanelBackground,
+                padding: '12px 16px',
+                borderRadius: '4px',
               }}
             >
               {isArticle ? (
@@ -382,6 +396,7 @@ export default async function handler(
                   xmlns="http://www.w3.org/2000/svg"
                   style={{
                     marginRight: '10px',
+                    filter: overlayDropShadow,
                   }}
                 >
                   <path
@@ -415,6 +430,7 @@ export default async function handler(
                     whiteSpace: 'pre-wrap',
                     textTransform: 'uppercase',
                     paddingLeft: '3px',
+                    textShadow: overlayTextShadow,
                   }}
                 >
                   <span>{siteConfigs.title}</span>

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -40,7 +40,10 @@ function sanitizeImageUrl(url: string): string {
 
     if (!allowedHost) return ''
 
-    const portPart = parsed.port ? `:${parsed.port}` : ''
+    const isLocal = allowedHost === 'localhost' || allowedHost === '127.0.0.1'
+    const defaultPort = parsed.protocol === 'https:' ? '443' : '80'
+    if (!isLocal && parsed.port && parsed.port !== defaultPort) return ''
+    const portPart = isLocal && parsed.port ? `:${parsed.port}` : ''
     const safe = new URL(`${parsed.protocol}//${allowedHost}${portPart}`)
 
     safe.pathname = parsed.pathname
@@ -104,7 +107,9 @@ export default async function handler(
     }
   }
   const searchParams = new URLSearchParams(safeDecode(rawQ))
-  const formatParam = (request.query['format'] as string) || ''
+  const formatRaw = request.query['format']
+  const formatParam =
+    (Array.isArray(formatRaw) ? formatRaw[0] : formatRaw) ?? ''
 
   const asJpeg =
     formatParam.toLowerCase() === 'jpg' || formatParam.toLowerCase() === 'jpeg'

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -20,6 +20,12 @@ const ALLOWED_IMAGE_HOSTS = new Set([
   '127.0.0.1',
 ])
 
+const CMS_ASSET_ORIGIN = (() => {
+  const raw =
+    process.env.NEXT_PUBLIC_ASSETS_BASE_URL || 'https://cms-press.logos.co'
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw
+})()
+
 /**
  * Validate that an image URL points to a trusted host.
  * Returns the original URL if valid, empty string otherwise.
@@ -53,6 +59,20 @@ function sanitizeImageUrl(url: string): string {
   } catch {
     return ''
   }
+}
+
+function isSupportedOgImageUrl(url: string): boolean {
+  return /\.(png|jpe?g)(\?|$)/i.test(url)
+}
+
+function sanitizeCmsUploadPath(value: string): string {
+  if (!value.startsWith('/uploads/')) return ''
+  if (value.includes('..')) return ''
+  return value
+}
+
+function buildCmsImageUrl(uploadPath: string): string {
+  return new URL(uploadPath, `${CMS_ASSET_ORIGIN}/`).toString()
 }
 
 /**
@@ -122,26 +142,33 @@ export default async function handler(
       : sanitizeText(searchParams.get('title'))
 
   const image = sanitizeImageUrl(searchParams.get('image') || '')
+  const imagePath = sanitizeCmsUploadPath(searchParams.get('imagePath') || '')
   const alt = sanitizeText(searchParams.get('alt') || '') || ''
   const pagePath =
     sanitizeText(searchParams.get('pagePath')) || 'press.logos.co'
   const date = searchParams.get('date')
   const authors = sanitizeText(searchParams.get('authors'))
 
-  let imgSrc = image
-  if (imgSrc && !/\.(png|jpe?g)(\?|$)/i.test(imgSrc)) {
+  const directImageUrl =
+    image && isSupportedOgImageUrl(image)
+      ? image
+      : imagePath && isSupportedOgImageUrl(imagePath)
+      ? buildCmsImageUrl(imagePath)
+      : ''
+  let imgSrc = directImageUrl
+
+  if (!imgSrc && imagePath) {
     try {
-      const res = await fetch(imgSrc)
+      const sourceUrl = buildCmsImageUrl(imagePath)
+      const res = await fetch(sourceUrl)
       if (res.ok) {
         const pngBuf = await sharp(Buffer.from(await res.arrayBuffer()))
           .png()
           .toBuffer()
         imgSrc = `data:image/png;base64,${pngBuf.toString('base64')}`
-      } else {
-        imgSrc = ''
       }
-    } catch {
-      imgSrc = ''
+    } catch (e) {
+      console.error('[og] Failed to load CMS upload image', e)
     }
   }
   const hasImage = !!imgSrc?.length

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -33,16 +33,18 @@ function sanitizeImageUrl(url: string): string {
     if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return ''
     // Look up the hostname from our allowlist , use the Set value, not the
     // user-provided string, so the returned URL is not considered tainted.
+
     const allowedHost = Array.from(ALLOWED_IMAGE_HOSTS).find(
       (h) => h === parsed.hostname,
     )
+
     if (!allowedHost) return ''
-    // Reconstruct from known-safe components to break CodeQL taint chain.
-    // Preserve the port so that local dev URLs like http://localhost:1337/uploads/...
-    // are not silently rewritten to http://localhost/uploads/... (which would 404).
+
     const portPart = parsed.port ? `:${parsed.port}` : ''
     const safe = new URL(`${parsed.protocol}//${allowedHost}${portPart}`)
+
     safe.pathname = parsed.pathname
+
     safe.search = parsed.search
     return safe.href
   } catch {
@@ -102,17 +104,18 @@ export default async function handler(
     }
   }
   const searchParams = new URLSearchParams(safeDecode(rawQ))
-  // `?format=jpg` opts into a small, long-cacheable JPEG. The default PNG
-  // path stays identical for backwards-compatibility. JPEG is used by the
-  // Strapi lifecycle hook that pre-generates og_image at publish time.
   const formatParam = (request.query['format'] as string) || ''
+
   const asJpeg =
     formatParam.toLowerCase() === 'jpg' || formatParam.toLowerCase() === 'jpeg'
+
   const contentType = searchParams.get('contentType')
+
   const title =
     contentType == null
       ? siteConfigs.heroTitle.join('')
       : sanitizeText(searchParams.get('title'))
+
   const image = sanitizeImageUrl(searchParams.get('image') || '')
   const alt = sanitizeText(searchParams.get('alt') || '') || ''
   const pagePath =
@@ -464,10 +467,7 @@ export default async function handler(
     const pngBuffer = Buffer.from(arrayBuffer)
 
     if (asJpeg) {
-      // Strapi's lifecycle hook calls this path to store a compact,
-      // long-cacheable JPEG in the CMS media library. Quality 75 +
-      // mozjpeg typically lands around 80–150KB at 1200×630, which
-      // stays well under Twitterbot's scrape budget.
+      // Strapi's lifecycle hook calls this path to store a JPEG in the CMS media library
       const jpegBuffer = await sharp(pngBuffer)
         .jpeg({ quality: 75, progressive: true, mozjpeg: true })
         .toBuffer()

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -128,7 +128,22 @@ export default async function handler(
   const date = searchParams.get('date')
   const authors = sanitizeText(searchParams.get('authors'))
 
-  const imgSrc = image
+  let imgSrc = image
+  if (imgSrc && !/\.(png|jpe?g)(\?|$)/i.test(imgSrc)) {
+    try {
+      const res = await fetch(imgSrc)
+      if (res.ok) {
+        const pngBuf = await sharp(Buffer.from(await res.arrayBuffer()))
+          .png()
+          .toBuffer()
+        imgSrc = `data:image/png;base64,${pngBuf.toString('base64')}`
+      } else {
+        imgSrc = ''
+      }
+    } catch {
+      imgSrc = ''
+    }
+  }
   const hasImage = !!imgSrc?.length
 
   const parsedDate = date ? new Date(date) : null
@@ -146,12 +161,8 @@ export default async function handler(
   const subtitleGap = isArticle && hasImage ? '16px' : '24px'
   const subtitleMargin = isArticle && hasImage ? '24px' : '40px'
 
-  // Wrap ImageResponse in try-catch: the underlying WASM renderer (@resvg/resvg-wasm
-  // used by @vercel/og outside Vercel's Edge network) can throw RuntimeError:
-  // unreachable on malformed input or OOM. Without this guard the error
-  // propagates uncaught, corrupts the WASM module state, and leaks memory on
-  // every subsequent request.
   let imageResponse: ImageResponse
+
   try {
     imageResponse = new ImageResponse(
       // Article with image: use full-bleed image background and overlay text

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -4,6 +4,7 @@ import fs from 'fs'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { ImageResponse } from 'next/og'
 import path from 'path'
+import sharp from 'sharp'
 
 let loraBuffer: Buffer | null = null
 let interBuffer: Buffer | null = null
@@ -37,7 +38,10 @@ function sanitizeImageUrl(url: string): string {
     )
     if (!allowedHost) return ''
     // Reconstruct from known-safe components to break CodeQL taint chain.
-    const safe = new URL(`${parsed.protocol}//${allowedHost}`)
+    // Preserve the port so that local dev URLs like http://localhost:1337/uploads/...
+    // are not silently rewritten to http://localhost/uploads/... (which would 404).
+    const portPart = parsed.port ? `:${parsed.port}` : ''
+    const safe = new URL(`${parsed.protocol}//${allowedHost}${portPart}`)
     safe.pathname = parsed.pathname
     safe.search = parsed.search
     return safe.href
@@ -98,6 +102,12 @@ export default async function handler(
     }
   }
   const searchParams = new URLSearchParams(safeDecode(rawQ))
+  // `?format=jpg` opts into a small, long-cacheable JPEG. The default PNG
+  // path stays identical for backwards-compatibility. JPEG is used by the
+  // Strapi lifecycle hook that pre-generates og_image at publish time.
+  const formatParam = (request.query['format'] as string) || ''
+  const asJpeg =
+    formatParam.toLowerCase() === 'jpg' || formatParam.toLowerCase() === 'jpeg'
   const contentType = searchParams.get('contentType')
   const title =
     contentType == null
@@ -451,9 +461,25 @@ export default async function handler(
   try {
     // ImageResponse is a Web API Response. Pipe its body into NextApiResponse.
     const arrayBuffer = await imageResponse.arrayBuffer()
+    const pngBuffer = Buffer.from(arrayBuffer)
+
+    if (asJpeg) {
+      // Strapi's lifecycle hook calls this path to store a compact,
+      // long-cacheable JPEG in the CMS media library. Quality 75 +
+      // mozjpeg typically lands around 80–150KB at 1200×630, which
+      // stays well under Twitterbot's scrape budget.
+      const jpegBuffer = await sharp(pngBuffer)
+        .jpeg({ quality: 75, progressive: true, mozjpeg: true })
+        .toBuffer()
+      res.setHeader('Content-Type', 'image/jpeg')
+      res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+      res.status(200).send(jpegBuffer)
+      return
+    }
+
     res.setHeader('Content-Type', 'image/png')
     res.setHeader('Cache-Control', 'public, max-age=3600, immutable')
-    res.status(200).send(Buffer.from(arrayBuffer))
+    res.status(200).send(pngBuffer)
   } catch (e) {
     console.error('[og] Failed to pipe image response', e)
     res.status(500).send('Failed to send OG image')

--- a/src/pages/article/[...path].tsx
+++ b/src/pages/article/[...path].tsx
@@ -22,6 +22,7 @@ const ArticlePage = ({ data, errors, why }: ArticleProps) => {
         description={data.data.summary}
         noIndex={data.data.isDraft}
         image={data.data.coverImage}
+        ogImage={data.data.ogImage}
         pagePath={`/article/${data.data.slug}`}
         date={data.data.createdAt}
         tags={[

--- a/src/services/images.service.ts
+++ b/src/services/images.service.ts
@@ -7,7 +7,6 @@ import {
 import axios from 'axios'
 import path from 'path'
 import sharp from 'sharp'
-import logger from '../lib/logger'
 
 // Maximum number of pixelated placeholder paths kept in memory.
 // Each entry is a small string, but without a cap the Map grows for every
@@ -17,6 +16,7 @@ const MAX_PLACEHOLDER_CACHE_SIZE = 500
 
 export class PlaceholderService {
   cache = new Map<string, string>()
+  failed = new Set<string>()
   constructor() {}
 
   add(key: string, value: string) {
@@ -34,6 +34,7 @@ export class PlaceholderService {
 
   emptyCache() {
     this.cache.clear()
+    this.failed.clear()
   }
 
   async pixelate(imagePath: string): Promise<string> {
@@ -73,19 +74,9 @@ export class PlaceholderService {
 
       return relativePath
     } catch (e) {
-      const relativePath = path.join(POSTS_IMAGE_PLACEHOLDER_DIR, fileName)
-      logger.debug('Image generation failed', {
-        fileName,
-        imagePath,
-        thumbnailPath,
-        error: e,
-        errorType: typeof e,
-        filePath: path.join(
-          process.env.SOURCE_DIR ?? process.cwd(),
-          relativePath,
-        ),
-      })
-      logger.error('Failed to generate image', { error: e })
+      if (!this.failed.has(fileName)) {
+        this.failed.add(fileName)
+      }
     }
 
     return thumbnailPath

--- a/src/services/strapi/strapi.operators.ts
+++ b/src/services/strapi/strapi.operators.ts
@@ -25,6 +25,15 @@ const POST_COMMON_ATTRIBUTES = gql`
         }
       }
     }
+    og_image {
+      data {
+        attributes {
+          url
+          width
+          height
+        }
+      }
+    }
     authors {
       data {
         id

--- a/src/services/strapi/strapi.operators.ts
+++ b/src/services/strapi/strapi.operators.ts
@@ -31,6 +31,8 @@ const POST_COMMON_ATTRIBUTES = gql`
           url
           width
           height
+          caption
+          alternativeText
         }
       }
     }

--- a/src/services/strapi/transformers/Post.transformer.ts
+++ b/src/services/strapi/transformers/Post.transformer.ts
@@ -120,6 +120,46 @@ export const postTransformer: Transformer<
       : undefined
     const coverImage: LPE.Post.Document['coverImage'] =
       await transformStrapiImageData(attributes.cover_image)
+    // Pre-generated OG image stored by the Strapi lifecycle hook. When
+    // present, the frontend SEO component will use this directly as
+    // og:image / twitter:image instead of hitting the dynamic /api/og.
+    //
+    // Intentionally NOT using transformStrapiImageData here — that
+    // helper also generates a base64 placeholder (pixelate) in non-Vercel
+    // deployments, which would download and process every og_image once
+    // per render on list pages. SEO only reads `ogImage.url`, so a
+    // minimal extraction is sufficient and much cheaper.
+    //
+    // `og_image` may be absent from the generated GraphQL types until
+    // codegen is rerun against the updated CMS schema; narrow through
+    // unknown so this compiles either way.
+    const ogImage: LPE.Image.Document | null = (() => {
+      const raw = (
+        attributes as unknown as {
+          og_image?: {
+            data?: {
+              attributes?: {
+                url?: string | null
+                width?: number | null
+                height?: number | null
+                caption?: string | null
+                alternativeText?: string | null
+              }
+            } | null
+          } | null
+        }
+      ).og_image
+      const attrs = raw?.data?.attributes
+      if (!attrs?.url) return null
+      return {
+        url: transformStrapiImageUrl(attrs.url),
+        width: attrs.width || 0,
+        height: attrs.height || 0,
+        alt: attrs.caption || attrs.alternativeText || '',
+        caption: attrs.caption || '',
+        placeholder: '',
+      }
+    })()
     const tags: LPE.Tag.Document[] = attributes.tags.data.map((tag) => ({
       id: tag.id,
       name: tag.attributes.name,
@@ -214,6 +254,7 @@ export const postTransformer: Transformer<
         createdAt: publishedAt,
         publishedAt,
         coverImage,
+        ogImage,
         tags,
         content,
         ...dynamicBlocksField,

--- a/src/services/strapi/transformers/Post.transformer.ts
+++ b/src/services/strapi/transformers/Post.transformer.ts
@@ -120,19 +120,7 @@ export const postTransformer: Transformer<
       : undefined
     const coverImage: LPE.Post.Document['coverImage'] =
       await transformStrapiImageData(attributes.cover_image)
-    // Pre-generated OG image stored by the Strapi lifecycle hook. When
-    // present, the frontend SEO component will use this directly as
-    // og:image / twitter:image instead of hitting the dynamic /api/og.
-    //
-    // Intentionally NOT using transformStrapiImageData here — that
-    // helper also generates a base64 placeholder (pixelate) in non-Vercel
-    // deployments, which would download and process every og_image once
-    // per render on list pages. SEO only reads `ogImage.url`, so a
-    // minimal extraction is sufficient and much cheaper.
-    //
-    // `og_image` may be absent from the generated GraphQL types until
-    // codegen is rerun against the updated CMS schema; narrow through
-    // unknown so this compiles either way.
+    // Pre-generated OG image stored by the Strapi lifecycle hook
     const ogImage: LPE.Image.Document | null = (() => {
       const raw = (
         attributes as unknown as {

--- a/src/types/lpe.types.ts
+++ b/src/types/lpe.types.ts
@@ -250,6 +250,7 @@ export namespace LPE {
       toc: Post.Toc
       readingTime: number
       coverImage: Image.Document | null
+      ogImage: Image.Document | null
       content: Array<Article.ContentBlock>
       blocks?: Post.DynamicBlock[]
       htmlFile?: Post.HtmlFile


### PR DESCRIPTION
OG images for articles frequently fail to appear on X (Twitter) because the dynamic `/api/og` route times out under Twitter's scraping process.

This PR pre-generates a compact JPEG at publish time via a Strapi lifecycle hook and stores it in the CMS media library. The SEO component uses the static URL directly, falling back to the existing dynamic route for posts without a pre-generated image.


## Discord discussion
https://discord.com/channels/973324189794697286/1488647558418137190/1488647561920122943

## Backend PR
https://github.com/acid-info/lpe-cms/pull/5

## Testing guide
In the backend PR: https://github.com/acid-info/lpe-cms/pull/5