### PR TITLE
fix(home): load all highlighted posts so "Show More" doesn't skip content

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ import logger from '../lib/logger'
 import { Enum_Post_Type } from '../lib/strapi/strapi.generated'
 import { strapiApi } from '../services/strapi'
 import { CalendarEvent } from '../types/data.types'
+import { LPE } from '../types/lpe.types'
 
 type PageProps = Pick<
   HomePageProps,
@@ -45,6 +46,32 @@ async function isFileOlderThan(
     // If file doesn't exist or can't be read, treat as stale
     return true
   }
+}
+
+// Batch size per Strapi request when paginating through all highlighted posts.
+// Matches Strapi v4's default maxLimit; the helper loops via `hasMore` until exhausted.
+const HIGHLIGHTED_PAGE_SIZE = 100
+
+async function fetchAllHighlightedPosts(type: Enum_Post_Type) {
+  const all: LPE.Post.Document[] = []
+  let skip = 0
+
+  while (true) {
+    const { data: response } = await strapiApi.getPosts({
+      highlighted: 'only',
+      skip,
+      limit: HIGHLIGHTED_PAGE_SIZE,
+      filters: { type: { eq: type } },
+    })
+
+    const page = response?.data ?? []
+    all.push(...page)
+
+    if (!response?.hasMore || page.length === 0) break
+    skip += page.length
+  }
+
+  return all
 }
 
 const Page: CustomNextPage<PageProps> = (props) => {
@@ -76,16 +103,9 @@ Page.getLayout = function getLayout(page: ReactNode) {
 }
 
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
-  const { data: allHighlightedArticlesResponse } = await strapiApi.getPosts({
-    highlighted: 'only',
-    filters: {
-      type: {
-        eq: 'Article' as Enum_Post_Type,
-      },
-    },
-  })
-
-  const allHighlightedArticles = allHighlightedArticlesResponse?.data || []
+  const allHighlightedArticles = await fetchAllHighlightedPosts(
+    'Article' as Enum_Post_Type,
+  )
 
   const initialHighlightedArticles = allHighlightedArticles.slice(
     0,
@@ -119,16 +139,9 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
     ...nonHighlightedArticles,
   ]
 
-  const { data: allHighlightedEpisodesResponse } = await strapiApi.getPosts({
-    highlighted: 'only',
-    filters: {
-      type: {
-        eq: 'Episode' as Enum_Post_Type,
-      },
-    },
-  })
-
-  const allHighlightedEpisodes = allHighlightedEpisodesResponse?.data || []
+  const allHighlightedEpisodes = await fetchAllHighlightedPosts(
+    'Episode' as Enum_Post_Type,
+  )
 
   const initialHighlightedEpisodes = allHighlightedEpisodes.slice(
     0,


### PR DESCRIPTION
## Request
https://discord.com/channels/864066763682218004/1447610467144171693/1496550110065197254

## Summary
- `getStaticProps` fetched highlighted articles/episodes without a `limit`, falling back to the default `10` and silently truncating any beyond the 10th.
- Replaced the single bounded call with a `fetchAllHighlightedPosts` helper that paginates via `hasMore` in batches of 100.

Merging this as this is a hotfix to address the bug.