### PR TITLE
fix: correct reading time for articles using external HTML content

### DIFF
--- a/src/pages/article/[...path].tsx
+++ b/src/pages/article/[...path].tsx
@@ -1,6 +1,9 @@
 import { SEO } from '@/components/SEO'
 import ArticleContainer from '@/containers/ArticleContainer'
-import { parseHtmlDocument } from '@/utils/html-document.utils'
+import {
+  calcHtmlReadingTime,
+  parseHtmlDocument,
+} from '@/utils/html-document.utils'
 import { GetStaticPropsContext } from 'next'
 import { strapiApi } from '../../services/strapi'
 import { LPE } from '../../types/lpe.types'
@@ -147,6 +150,9 @@ export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
         if (response.ok) {
           const html = await response.text()
           article.htmlDocument = parseHtmlDocument(html)
+          // The transformer has no body text for html_file articles, so it
+          // defaults reading time to 1 min. Recompute it from the fetched HTML.
+          article.readingTime = calcHtmlReadingTime(html)
         } else {
           console.warn('[ArticlePage] Failed to fetch html document', {
             rawUrl,

--- a/src/utils/html-document.utils.ts
+++ b/src/utils/html-document.utils.ts
@@ -92,3 +92,26 @@ export const parseHtmlDocument = (html: string): LPE.Post.HtmlDocument => {
 
   return cleanObject(doc) as LPE.Post.HtmlDocument
 }
+
+/**
+ * Compute reading time (in minutes) from a raw HTML document.
+ *
+ * Used only for articles whose body lives in an external html_file, where the
+ * Strapi transformer has no text to measure and would otherwise return 1 min.
+ * Kept independent from calcReadingTime so existing (body/markdown) articles
+ * keep their exact reading-time values.
+ */
+const WORDS_PER_MINUTE = 200
+
+export const calcHtmlReadingTime = (html: string): number => {
+  const root = parse(html)
+  root.querySelectorAll('script').forEach((script) => script.remove())
+  root.querySelectorAll('style').forEach((style) => style.remove())
+  const body = root.querySelector('body') || root
+  const numberOfWords = (body.text || '')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length
+  if (numberOfWords === 0) return 0
+  return Math.max(1, Math.ceil(numberOfWords / WORDS_PER_MINUTE))
+}


### PR DESCRIPTION
## Summary
Articles whose body is served from an external `html_file` (e.g. `/article/dispersive-medium`) always showed "1 MIN" reading time, because the Strapi transformer has no body text to measure and defaults to 1 minute.

## Changes
- Add `calcHtmlReadingTime` helper that derives reading time from the fetched HTML body (excluding `<script>`/`<style>`).
- Recompute `article.readingTime` in the article page after the external HTML is fetched and parsed.

## Notes
- Only affects articles using `html_file`. Existing `body`/`markdown_body` articles are untouched — `calcReadingTime` is unchanged, and the new helper is fully independent.